### PR TITLE
Add notebook lyric generation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 - [Project Overview](#project-overview)  
 - [System Architecture & Workflow](#system-architecture--workflow)  
 - [Features](#features)  
-- [Technology Stack](#technology-stack)  
-- [Installation & Usage](#installation--usage)  
-- [Notice of Authorship and Academic Integrity](#notice-of-authorship-and-academic-integrity)  
+- [Technology Stack](#technology-stack)
+- [Installation & Usage](#installation--usage)
+- [Notice of Authorship and Academic Integrity](#notice-of-authorship-and-academic-integrity)
 - [License](#license)  
 
 ---
@@ -64,6 +64,38 @@ The goal is to create an end-to-end pipeline: a user provides a high-level creat
 - **Data Acquisition:** Kaggle Datasets, Genius API  
 - **Frontend:** HTML, CSS, JavaScript  
 - **Deployment (Optional):** Google Colab (training), Heroku / PythonAnywhere (hosting)
+
+---
+
+## Installation & Usage
+
+1. Install the core dependencies:
+
+   ```bash
+   pip install tensorflow google-generativeai audiocraft
+   ```
+
+2. Ensure your trained model files reside in the `Models/` folder and the tokenizer is available in `Tokenizer/tokenizer.pkl`.
+
+3. Set your Gemini API key (optional for Gemini lyrics):
+
+   ```bash
+   export GEMINI_API_KEY=<YOUR_KEY>
+   ```
+
+4. Run the generator script and follow the prompts (CLI option):
+
+   ```bash
+   python generate_song.py
+   ```
+
+5. Or start the FastAPI server:
+
+   ```bash
+   uvicorn app:app --reload
+   ```
+
+Use the `/generate` endpoint to retrieve lyrics from both models and `/song` to create an `.mp3` from your chosen lyrics.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from fastapi.responses import FileResponse
+import os
+
+from generate_song import (
+    load_tokenizer,
+    load_latest_model,
+    generate_with_local_model,
+    generate_with_gemini,
+    create_song_from_lyrics,
+    genai,
+)
+
+app = FastAPI(title="AI Song Generator")
+
+# Load resources once at startup
+TOKENIZER = load_tokenizer()
+MODEL = load_latest_model()
+API_KEY = os.environ.get("GEMINI_API_KEY")
+
+class Prompt(BaseModel):
+    text: str
+    max_words: int = 50
+
+class Lyrics(BaseModel):
+    lyrics: str
+    model_name: str | None = None
+
+@app.post("/generate")
+def generate(prompt: Prompt):
+    local = generate_with_local_model(prompt.text, TOKENIZER, MODEL, max_words=prompt.max_words)
+    gemini_lyrics = None
+    if API_KEY and genai:
+        try:
+            gemini_lyrics = generate_with_gemini(prompt.text, API_KEY)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc))
+    return {"local": local, "gemini": gemini_lyrics}
+
+@app.post("/song")
+def song(data: Lyrics):
+    try:
+        path = create_song_from_lyrics(data.lyrics)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return FileResponse(path, media_type="audio/mpeg", filename=os.path.basename(path))

--- a/generate_song.py
+++ b/generate_song.py
@@ -1,0 +1,118 @@
+import os
+import re
+import pickle
+import numpy as np
+
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing.sequence import pad_sequences
+
+# Optional imports for external services
+try:
+    import google.generativeai as genai
+except ImportError:  # pragma: no cover - library optional
+    genai = None
+
+try:
+    from audiocraft.models import MusicGen
+    from audiocraft.data.audio import audio_write
+except ImportError:  # pragma: no cover - library optional
+    MusicGen = None
+    audio_write = None
+
+TOKENIZER_PATH = os.path.join("Tokenizer", "tokenizer.pkl")
+MODELS_DIR = "Models"
+DEFAULT_OUTPUT = "generated_song.mp3"
+
+
+def load_tokenizer(path: str = TOKENIZER_PATH):
+    """Load the saved tokenizer."""
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def load_latest_model(directory: str = MODELS_DIR):
+    """Load the latest `.h5` model from the Models directory."""
+    files = [f for f in os.listdir(directory) if f.endswith(".h5")]
+    if not files:
+        raise FileNotFoundError("No model files found in 'Models' directory")
+
+    def version(fname: str) -> int:
+        match = re.search(r"_v(\d+)", fname)
+        return int(match.group(1)) if match else -1
+
+    latest = max(files, key=version)
+    model = load_model(os.path.join(directory, latest))
+    return model
+
+
+def generate_song_line(seed_text: str, tokenizer, model, next_words: int = 50) -> str:
+    """Generate lyrics using the notebook-style loop provided by the user."""
+    max_seq_len = model.input_shape[1] + 1
+    for _ in range(next_words):
+        token_list = tokenizer.texts_to_sequences([seed_text])[0]
+        token_list = pad_sequences([token_list], maxlen=max_seq_len - 1, padding="pre")
+        predicted = model.predict(token_list, verbose=0)
+        output_word = tokenizer.index_word.get(int(np.argmax(predicted)))
+        if not output_word:
+            break
+        seed_text += " " + output_word
+    return seed_text
+
+
+def generate_with_local_model(prompt: str, tokenizer, model, max_words: int = 50) -> str:
+    """Generate lyrics using the local model with padding."""
+    return generate_song_line(prompt, tokenizer, model, next_words=max_words)
+
+
+def generate_with_gemini(prompt: str, api_key: str, model_name: str = "gemini-pro") -> str:
+    """Generate lyrics using the Gemini API."""
+    if genai is None:
+        raise RuntimeError("google-generativeai library is not installed")
+
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel(model_name)
+    response = model.generate_content(prompt)
+    return response.text.strip()
+
+
+def create_song_from_lyrics(lyrics: str, output_path: str = DEFAULT_OUTPUT, model_name: str = "facebook/musicgen-small") -> str:
+    """Generate an MP3 file from text lyrics using MusicGen."""
+    if MusicGen is None or audio_write is None:
+        raise RuntimeError("audiocraft library is required for music generation")
+
+    musicgen = MusicGen.get_pretrained(model_name)
+    wav = musicgen.generate([lyrics])[0]
+    audio_write(output_path.split(".")[0], wav, musicgen.sample_rate, format="mp3")
+    return output_path
+
+
+def main():
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        print("Warning: GEMINI_API_KEY environment variable not set. Gemini lyrics will fail without it.")
+
+    prompt = input("Enter a song description: ")
+
+    tokenizer = load_tokenizer()
+    model = load_latest_model()
+
+    local_lyrics = generate_with_local_model(prompt, tokenizer, model)
+    gemini_lyrics = generate_with_gemini(prompt, api_key) if api_key and genai else "[Gemini not available]"
+
+    print("\n--- Local Model Lyrics ---\n")
+    print(local_lyrics)
+    print("\n--- Gemini Lyrics ---\n")
+    print(gemini_lyrics)
+
+    choice = input("Choose lyrics to turn into music (1=Local, 2=Gemini): ").strip()
+    selected = local_lyrics if choice != "2" else gemini_lyrics
+
+    try:
+        path = create_song_from_lyrics(selected)
+        print(f"Saved generated song to {path}")
+    except Exception as e:
+        print(f"Music generation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adapt local lyric generation to use the same loop as in the notebook example
- expose the new helper through `generate_with_local_model`

## Testing
- `python -m py_compile generate_song.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68743b38167883218fc54cb38dacc052